### PR TITLE
fix gha set-output command

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -138,7 +138,7 @@ Next, add a step to read a mdBook version from the `.env` file.
       id: mdbook-version
       run: |
         . ./.env
-        echo "::set-output name=MDBOOK_VERSION::${MDBOOK_VERSION}"
+        echo "MDBOOK_VERSION=${MDBOOK_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Setup mdBook
       uses: peaceiris/actions-mdbook@v1


### PR DESCRIPTION
GitHub is going to deprecate `save-state` and `set-output` commands. [More info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR adjusts documentation to new syntax.

Part of https://github.com/paritytech/ci_cd/issues/805