### PR TITLE
Typo in filename

### DIFF
--- a/src/guides/parachain_deployment.md
+++ b/src/guides/parachain_deployment.md
@@ -108,7 +108,7 @@ If you want to select a specific built-in runtimle of your binary, add `--chain 
 
 ### Prepare your genesis patch config
 
-Save the following to `genesis-patch.json` (replace keys and configuration with your own):
+Save the following to `genesis.patch.json` (replace keys and configuration with your own):
 ```json
 {
   "balances": {


### PR DESCRIPTION
In the next step, `genesis.patch.json` is referenced.